### PR TITLE
Increase max light output to 1000

### DIFF
--- a/custom_components/sony_projector_adcp/media_player.py
+++ b/custom_components/sony_projector_adcp/media_player.py
@@ -80,7 +80,7 @@ async def async_setup_entry(
     
     platform.async_register_entity_service(
         SERVICE_SET_LIGHT_OUTPUT,
-        {vol.Required(ATTR_VALUE): vol.All(vol.Coerce(int), vol.Range(min=0, max=100))},
+        {vol.Required(ATTR_VALUE): vol.All(vol.Coerce(int), vol.Range(min=0, max=1000))},
         "async_set_light_output",
     )
     


### PR DESCRIPTION
Light output scales from 0 to 1000 (contrary to brightness, contrast and sharpness that scale from 0 to 100).